### PR TITLE
Load common modules via environs.access-om2.nci, and improve crash diagnostics

### DIFF
--- a/bld/Macros.nci
+++ b/bld/Macros.nci
@@ -20,7 +20,7 @@ ifeq ($(DEBUG), 1)
     FFLAGS     := -r8 -i4 -O0 -traceback -g -debug all -check all -no-vec -align all -w -fpe0 -ftz -convert big_endian -assume byterecl -assume nobuffered_io -check noarg_temp_created
     CPPDEFS    := $(CPPDEFS) -DDEBUG=$(DEBUG)
 else
-    FFLAGS     := -r8 -i4 -O2 -align all -xHost -fpe0 -w -ftz -convert big_endian -assume byterecl -assume buffered_io -check noarg_temp_created
+    FFLAGS     := -r8 -i4 -O2 -traceback -g -align all -xHost -fpe0 -w -ftz -convert big_endian -assume byterecl -assume buffered_io -check noarg_temp_created
 endif
 
 MOD_SUFFIX := mod

--- a/bld/config.nci.auscom.1440x1080
+++ b/bld/config.nci.auscom.1440x1080
@@ -16,9 +16,9 @@ setenv BLCKX `expr $NXGLOB / 24`       # x-dimension of blocks ( not including )
 setenv BLCKY `expr $NYGLOB / 20`         # y-dimension of blocks (  ghost cells  )
 
 source /etc/profile.d/nf_csh_modules
-if ( -f ../../../modules.nci ) then
+if ( -f ../../modules.nci ) then
     echo "Loading common modules via modules.nci"
-    source ../../../modules.nci
+    source ../../modules.nci
 else
     echo "WARNING: modules.nci not found. Module versions might differ between model components."
     module purge

--- a/bld/config.nci.auscom.1440x1080
+++ b/bld/config.nci.auscom.1440x1080
@@ -16,8 +16,14 @@ setenv BLCKX `expr $NXGLOB / 24`       # x-dimension of blocks ( not including )
 setenv BLCKY `expr $NYGLOB / 20`         # y-dimension of blocks (  ghost cells  )
 
 source /etc/profile.d/nf_csh_modules
-module purge
-module load intel-fc/17.0.1.132
-module load intel-cc/17.0.1.132
-module load netcdf/4.3.2
-module load openmpi/1.10.2
+if ( -f ../../../modules.nci ) then
+    echo "Loading common modules via modules.nci"
+    source ../../../modules.nci
+else
+    echo "WARNING: modules.nci not found. Module versions might differ between model components."
+    module purge
+    module load intel-fc/17.0.1.132
+    module load intel-cc/17.0.1.132
+    module load netcdf/4.3.2
+    module load openmpi/1.10.2
+endif

--- a/bld/config.nci.auscom.1440x1080
+++ b/bld/config.nci.auscom.1440x1080
@@ -16,11 +16,11 @@ setenv BLCKX `expr $NXGLOB / 24`       # x-dimension of blocks ( not including )
 setenv BLCKY `expr $NYGLOB / 20`         # y-dimension of blocks (  ghost cells  )
 
 source /etc/profile.d/nf_csh_modules
-if ( -f ../../modules.nci ) then
-    echo "Loading common modules via modules.nci"
-    source ../../modules.nci
+if ( -f ../../environs.access-om2.nci ) then
+    echo "Loading common modules via environs.access-om2.nci"
+    source ../../environs.access-om2.nci
 else
-    echo "WARNING: modules.nci not found. Module versions might differ between model components."
+    echo "WARNING: environs.access-om2.nci not found. Module versions might differ between model components."
     module purge
     module load intel-fc/17.0.1.132
     module load intel-cc/17.0.1.132

--- a/bld/config.nci.auscom.3600x2700
+++ b/bld/config.nci.auscom.3600x2700
@@ -16,11 +16,11 @@ setenv BLCKX `expr $NXGLOB / 40`       # x-dimension of blocks ( not including )
 setenv BLCKY `expr $NYGLOB / 30`         # y-dimension of blocks (  ghost cells  )
 
 source /etc/profile.d/nf_csh_modules
-if ( -f ../../modules.nci ) then
-    echo "Loading common modules via modules.nci"
-    source ../../modules.nci
+if ( -f ../../environs.access-om2.nci ) then
+    echo "Loading common modules via environs.access-om2.nci"
+    source ../../environs.access-om2.nci
 else
-    echo "WARNING: modules.nci not found. Module versions might differ between model components."
+    echo "WARNING: environs.access-om2.nci not found. Module versions might differ between model components."
     module purge
     module load intel-fc/17.0.1.132
     module load intel-cc/17.0.1.132

--- a/bld/config.nci.auscom.3600x2700
+++ b/bld/config.nci.auscom.3600x2700
@@ -16,8 +16,14 @@ setenv BLCKX `expr $NXGLOB / 40`       # x-dimension of blocks ( not including )
 setenv BLCKY `expr $NYGLOB / 30`         # y-dimension of blocks (  ghost cells  )
 
 source /etc/profile.d/nf_csh_modules
-module purge
-module load intel-fc/17.0.1.132
-module load intel-cc/17.0.1.132
-module load netcdf/4.3.2
-module load openmpi/1.10.2
+if ( -f ../../../modules.nci ) then
+    echo "Loading common modules via modules.nci"
+    source ../../../modules.nci
+else
+    echo "WARNING: modules.nci not found. Module versions might differ between model components."
+    module purge
+    module load intel-fc/17.0.1.132
+    module load intel-cc/17.0.1.132
+    module load netcdf/4.3.2
+    module load openmpi/1.10.2
+endif

--- a/bld/config.nci.auscom.3600x2700
+++ b/bld/config.nci.auscom.3600x2700
@@ -16,9 +16,9 @@ setenv BLCKX `expr $NXGLOB / 40`       # x-dimension of blocks ( not including )
 setenv BLCKY `expr $NYGLOB / 30`         # y-dimension of blocks (  ghost cells  )
 
 source /etc/profile.d/nf_csh_modules
-if ( -f ../../../modules.nci ) then
+if ( -f ../../modules.nci ) then
     echo "Loading common modules via modules.nci"
-    source ../../../modules.nci
+    source ../../modules.nci
 else
     echo "WARNING: modules.nci not found. Module versions might differ between model components."
     module purge

--- a/bld/config.nci.auscom.360x300
+++ b/bld/config.nci.auscom.360x300
@@ -8,9 +8,9 @@ setenv BLCKX `expr $NXGLOB / 24`       # x-dimension of blocks ( not including )
 setenv BLCKY `expr $NYGLOB / 1`        # y-dimension of blocks (  ghost cells  )
 
 source /etc/profile.d/nf_csh_modules
-if ( -f ../../../modules.nci ) then
+if ( -f ../../modules.nci ) then
     echo "Loading common modules via modules.nci"
-    source ../../../modules.nci
+    source ../../modules.nci
 else
     echo "WARNING: modules.nci not found. Module versions might differ between model components."
     module purge

--- a/bld/config.nci.auscom.360x300
+++ b/bld/config.nci.auscom.360x300
@@ -8,11 +8,11 @@ setenv BLCKX `expr $NXGLOB / 24`       # x-dimension of blocks ( not including )
 setenv BLCKY `expr $NYGLOB / 1`        # y-dimension of blocks (  ghost cells  )
 
 source /etc/profile.d/nf_csh_modules
-if ( -f ../../modules.nci ) then
-    echo "Loading common modules via modules.nci"
-    source ../../modules.nci
+if ( -f ../../environs.access-om2.nci ) then
+    echo "Loading common modules via environs.access-om2.nci"
+    source ../../environs.access-om2.nci
 else
-    echo "WARNING: modules.nci not found. Module versions might differ between model components."
+    echo "WARNING: environs.access-om2.nci not found. Module versions might differ between model components."
     module purge
     module load intel-fc/17.0.1.132
     module load intel-cc/17.0.1.132

--- a/bld/config.nci.auscom.360x300
+++ b/bld/config.nci.auscom.360x300
@@ -8,8 +8,14 @@ setenv BLCKX `expr $NXGLOB / 24`       # x-dimension of blocks ( not including )
 setenv BLCKY `expr $NYGLOB / 1`        # y-dimension of blocks (  ghost cells  )
 
 source /etc/profile.d/nf_csh_modules
-module purge
-module load intel-fc/17.0.1.132
-module load intel-cc/17.0.1.132
-module load netcdf/4.3.2
-module load openmpi/1.10.2
+if ( -f ../../../modules.nci ) then
+    echo "Loading common modules via modules.nci"
+    source ../../../modules.nci
+else
+    echo "WARNING: modules.nci not found. Module versions might differ between model components."
+    module purge
+    module load intel-fc/17.0.1.132
+    module load intel-cc/17.0.1.132
+    module load netcdf/4.3.2
+    module load openmpi/1.10.2
+endif

--- a/mpi/ice_exit.F90
+++ b/mpi/ice_exit.F90
@@ -54,7 +54,7 @@
       call flush_fileunit(ice_stderr)
 
 #if defined(__INTEL_COMPILER)
-      call TRACEBACKQQ()
+      call TRACEBACKQQ(USER_EXIT_CODE=-1)
 #elif defined(__GFORTRAN__)
       call BACKTRACE()
 #endif

--- a/source/ice_therm_bl99.F90
+++ b/source/ice_therm_bl99.F90
@@ -146,7 +146,7 @@
       ! local variables
 
       integer (kind=int_kind), parameter :: &
-         nitermax = 100, & ! max number of iterations in temperature solver
+         nitermax = 500, & ! max number of iterations in temperature solver
          nmat = nslyr + nilyr + 1  ! matrix dimension
 
       real (kind=dbl_kind), parameter :: &
@@ -552,7 +552,7 @@
       !        conductive flux, fcondtopn.
       !    (5) The net energy added to the ice per unit time must equal 
       !        the net change in internal ice energy per unit time,
-      !        withinic the prescribed error ferrmax.
+      !        within the prescribed error ferrmax.
       !
       ! For briny ice (the standard case), zTsn and zTin are limited
       !  to prevent them from exceeding their melting temperatures.


### PR DESCRIPTION
As discussed here: 
https://arccss.slack.com/archives/C6PP0GU9Y/p1516678999000106
but `modules.nci` is now called `environs.access-om2.nci`
and specifies `openmpi/1.10.2`, not `openmpi/3.0.0`

There are related pull requests for the other model components.

This PR also has other changes related to crash diagnostics.