### PR TITLE
Added capability to split input and restart directories. 

### DIFF
--- a/drivers/auscom/CICE_InitMod.F90
+++ b/drivers/auscom/CICE_InitMod.F90
@@ -100,7 +100,7 @@
       use ice_transport_driver, only: init_transport
       use ice_zbgc, only: init_zbgc
       use ice_zbgc_shared, only: skl_bgc
-      use ice_restart_shared, only: restart_dir
+      use ice_restart_shared, only: restart_dir, input_dir
 #ifdef popcice
       use drv_forcing, only: sst_sss
 #endif
@@ -156,7 +156,7 @@
       if (runtype == 'initial') then
         nrec = month - 1            !month is from calendar
         if (nrec == 0) nrec = 12 
-        call get_time0_sstsss(trim(restart_dir)//'monthly_sstsss.nc', nrec)
+        call get_time0_sstsss(trim(input_dir)//'monthly_sstsss.nc', nrec)
 #if defined(DEBUG)
         write(il_out,*) 'CICE called  get_time0_sstsss. my_task = ',my_task
 #endif
@@ -167,7 +167,7 @@
       !20100111: get the surface friction velocity for gfdl surface flux calculation
       !          (roughness calculation requires last time step u_star...)
       if (gfdl_surface_flux) then
-         call get_u_star(trim(restart_dir)//'u_star.nc')
+         call get_u_star(trim(input_dir)//'u_star.nc')
       endif  
 
 #else

--- a/drivers/auscom/CICE_RunMod.F90
+++ b/drivers/auscom/CICE_RunMod.F90
@@ -63,7 +63,7 @@
       use ice_timers, only: ice_timer_start, ice_timer_stop, &
           timer_couple, timer_step
       use ice_zbgc_shared, only: skl_bgc
-      use ice_restart_shared, only: restart_dir
+      use ice_restart_shared, only: restart_dir, input_dir
 
 #ifdef AusCOM 
 !ars599: 27032014 add in
@@ -103,10 +103,10 @@
       !    last run from ocn and ice model;
       ! initial run needs the pre-processed o2i and i2o fields.
 
-      call get_time0_o2i_fields(trim(restart_dir)//'o2i.nc')
+      call get_time0_o2i_fields(trim(input_dir)//'o2i.nc')
 
-      call get_time0_i2o_fields(trim(restart_dir)//'i2o.nc')
-      call get_sicemass(trim(restart_dir)//'sicemass.nc')
+      call get_time0_i2o_fields(trim(input_dir)//'i2o.nc')
+      call get_sicemass(trim(input_dir)//'sicemass.nc')
 
       if (use_core_nyf_runoff) then
          stop "Don't do this"
@@ -148,7 +148,7 @@
            !call gather_global(gwork, u_star0, master_task, distrb_info)
            !if (my_task == master_task) write(54,'(10e12.4)')gwork
            !
-           call check_roughness(trim(restart_dir)//'fields_roughness.nc',stimestamp_io)
+           call check_roughness(trim(input_dir)//'fields_roughness.nc',stimestamp_io)
         endif
         ! ----------------------------------- 
 

--- a/source/ice_restart_driver.F90
+++ b/source/ice_restart_driver.F90
@@ -20,7 +20,7 @@
 
       use ice_kinds_mod
       use ice_restart_shared, only: &
-          restart, restart_ext, restart_dir, restart_file, pointer_file, &
+          restart, restart_ext, input_dir, restart_dir, restart_file, pointer_file, &
           runid, runtype, use_restart_time, restart_format, lcdf64, lenstr
       use ice_restart
 
@@ -571,6 +571,7 @@
          read(nu_rst_pointer,'(a)') filename0
          filename = trim(filename0)
 #ifdef AusCOM
+         write(nu_diag,*) 'XXX: input_dir = ', input_dir
          write(nu_diag,*) 'XXX: restart_dir = ', restart_dir
          write(nu_diag,*) 'XXX: org restart file => ', filename
 !ars599: 28042015 restart issue

--- a/source/ice_restart_shared.F90
+++ b/source/ice_restart_shared.F90
@@ -18,6 +18,7 @@
          runtype           ! initial, continue, hybrid, branch
 
       character (len=char_len_long), public :: &
+         input_dir     , & ! directory name for restart input
          restart_dir   , & ! directory name for restart dump
          runid             ! identifier for CESM coupled run or bering
 


### PR DESCRIPTION
Previously model input was all read from restart_dir and then restarts were
written to the same directory.

This change adds input_dir to the setup_nml namelist. By default, if
input_dir is not specified in the namelist it will be set to the same
as restart_dir, reproducing previous behaviour, and so making this
backwards compatible.

If input_dir is specified then all inputs will be read from the specified
directory, and restarts will be written to restart_dir.