### PR TITLE
Change default error code in abort_ice to 1

### DIFF
--- a/mpi/ice_exit.F90
+++ b/mpi/ice_exit.F90
@@ -39,7 +39,10 @@
       ! local variables
 
 #ifndef CCSMCOUPLED
-      integer (int_kind) :: ierr ! MPI error flag
+      ! MPI error flag, default to non-zero error
+      integer (int_kind) :: errorcode = 1 
+      ! MPI return value
+      integer (int_kind) :: ierr
 #endif
 
 #if (defined CCSMCOUPLED)
@@ -58,7 +61,7 @@
 #elif defined(__GFORTRAN__)
       call BACKTRACE()
 #endif
-      call MPI_ABORT(MPI_COMM_WORLD, ierr)
+      call MPI_ABORT(MPI_COMM_WORLD, errorcode, ierr)
 
       stop
 #endif


### PR DESCRIPTION
Fix for https://github.com/OceansAus/cice5/issues/8

Default error code passed to MPI_ABORT (and propagated to calling process) is now 1.

Tested and works with payu