### PR TITLE
libaccessom2 intercommunicator profiling support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,11 @@
+platform ?= nci
 
 1deg:
-	bld/build.sh nci auscom 360x300
+	bld/build.sh $(platform) auscom 360x300
 025deg:
-	bld/build.sh nci auscom 1440x1080
+	bld/build.sh $(platform) auscom 1440x1080
 01deg:
-	bld/build.sh nci auscom 3600x2700
+	bld/build.sh $(platform) auscom 3600x2700
 
 clean:
 	rm -rf build_*

--- a/bld/Macros.scorep
+++ b/bld/Macros.scorep
@@ -1,0 +1,81 @@
+#==============================================================================
+# Makefile macros for xe.nci.org.au, an SGI ALTIX system running Linux
+# Note:  Use the -mp flag if precision is critical.   It slows down the 
+#        code by 25% (or more).
+#==============================================================================
+
+INCLDIR    := -I.
+SLIBS      :=
+ULIBS      :=
+CPP        := cpp
+FC         := scorep mpif90
+
+CPPFLAGS   := -P -traditional
+CPPDEFS    := -DLINUX -DPAROPT
+CFLAGS     := -c -O2
+FIXEDFLAGS := -132
+FREEFLAGS  :=
+
+ifeq ($(DEBUG), 1)
+    FFLAGS     := -r8 -i4 -O0 -traceback -g -debug all -check all -no-vec -align all -w -fpe0 -ftz -convert big_endian -assume byterecl -assume nobuffered_io -check noarg_temp_created
+    CPPDEFS    := $(CPPDEFS) -DDEBUG=$(DEBUG)
+else
+    FFLAGS     := -r8 -i4 -O2 -traceback -g -align all -xHost -fpe0 -w -ftz -convert big_endian -assume byterecl -assume buffered_io -check noarg_temp_created
+endif
+
+MOD_SUFFIX := mod
+LD         := $(FC)
+LDFLAGS    := $(FFLAGS) -v
+
+CPPDEFS :=  $(CPPDEFS) -DNXGLOB=$(NXGLOB) -DNYGLOB=$(NYGLOB) \
+            -DNUMIN=$(NUMIN) -DNUMAX=$(NUMAX) \
+            -DTRAGE=$(TRAGE) -DTRFY=$(TRFY) -DTRLVL=$(TRLVL) \
+            -DTRPND=$(TRPND) -DNTRAERO=$(NTRAERO) -DTRBRI=$(TRBRI) \
+            -DNBGCLYR=$(NBGCLYR) -DTRBGCS=$(TRBGCS) \
+            -DNICECAT=$(NICECAT) -DNICELYR=$(NICELYR) \
+            -DNSNWLYR=$(NSNWLYR) \
+            -DBLCKX=$(BLCKX) -DBLCKY=$(BLCKY) -DMXBLCKS=$(MXBLCKS)
+
+ifeq ($(COMMDIR), mpi)
+   SLIBS   :=  $(SLIBS) -lmpi
+endif
+
+ifeq ($(DITTO), yes)
+   CPPDEFS :=  $(CPPDEFS) -DREPRODUCIBLE
+endif
+
+ifeq ($(IO_TYPE), netcdf)
+   CPPDEFS :=  $(CPPDEFS) -Dncdf
+   INCLDIR := $(INCLDIR) -I$(NETCDF_ROOT)/include
+   SLIBS   := $(SLIBS) -L$(NETCDF_ROOT)/lib -lnetcdf -lnetcdff
+endif
+
+ifeq ($(USE_ESMF), yes)
+   CPPDEFS :=  $(CPPDEFS) -Duse_esmf
+   INCLDIR :=  $(INCLDIR) -I ???
+   SLIBS   :=  $(SLIBS) -L ??? -lesmf -lcprts -lrt -ldl
+endif
+
+ifeq ($(AusCOM), yes)
+   CPPDEFS := $(CPPDEFS) -DAusCOM -Dcoupled
+   INCLDIR := $(INCLDIR) $(CPL_INCS) $(LIBAUSCOM_INCS)
+   SLIBS   := $(SLIBS) -L$(CPLLIBDIR) -laccessom2
+endif
+
+ifeq ($(UNIT_TESTING), yes)
+   CPPDEFS := $(CPPDEFS) -DUNIT_TESTING
+endif
+ifeq ($(ACCESS), yes)
+   CPPDEFS := $(CPPDEFS) -DACCESS
+endif
+# standalone CICE with AusCOM mods
+ifeq ($(ACCICE), yes)
+   CPPDEFS := $(CPPDEFS) -DACCICE
+endif
+# no MOM just CICE+UM
+ifeq ($(NOMOM), yes)
+   CPPDEFS := $(CPPDEFS) -DNOMOM
+endif
+ifeq ($(OASIS3_MCT), yes)
+   CPPDEFS := $(CPPDEFS) -DOASIS3_MCT
+endif

--- a/bld/config.scorep.auscom.1440x1080
+++ b/bld/config.scorep.auscom.1440x1080
@@ -1,0 +1,29 @@
+
+# Recommendations:
+#   use processor_shape = slenderX1 or slenderX2 in ice_in
+#   one per processor with distribution_type='cartesian' or
+#   squarish blocks with distribution_type='rake'
+# If BLCKX (BLCKY) does not divide NXGLOB (NYGLOB) evenly, padding
+# will be used on the right (top) of the grid.
+
+setenv NTASK 480
+setenv RES 1440x1080
+
+set NXGLOB = `echo $RES | sed s/x.\*//`
+set NYGLOB = `echo $RES | sed s/.\*x//`
+
+setenv BLCKX `expr $NXGLOB / 24`       # x-dimension of blocks ( not including )
+setenv BLCKY `expr $NYGLOB / 20`         # y-dimension of blocks (  ghost cells  )
+
+source /etc/profile.d/nf_csh_modules
+module purge
+module load intel-fc/17.0.1.132
+module load intel-cc/17.0.1.132
+module load netcdf/4.2.1.1
+module load openmpi/1.10.2
+module load scorep/3.1
+
+# correct papi module
+module unload papi
+module use /short/z35/dsr900/tools/Modules
+module load papi/5.1.1-patched

--- a/bld/config.scorep.auscom.3600x2700
+++ b/bld/config.scorep.auscom.3600x2700
@@ -1,0 +1,29 @@
+
+# Recommendations:
+#   use processor_shape = slenderX1 or slenderX2 in ice_in
+#   one per processor with distribution_type='cartesian' or
+#   squarish blocks with distribution_type='rake'
+# If BLCKX (BLCKY) does not divide NXGLOB (NYGLOB) evenly, padding
+# will be used on the right (top) of the grid.
+
+setenv NTASK 1200
+setenv RES 3600x2700
+
+set NXGLOB = `echo $RES | sed s/x.\*//`
+set NYGLOB = `echo $RES | sed s/.\*x//`
+
+setenv BLCKX `expr $NXGLOB / 40`       # x-dimension of blocks ( not including )
+setenv BLCKY `expr $NYGLOB / 30`         # y-dimension of blocks (  ghost cells  )
+
+source /etc/profile.d/nf_csh_modules
+module purge
+module load intel-fc/17.0.1.132
+module load intel-cc/17.0.1.132
+module load netcdf/4.2.1.1
+module load openmpi/1.10.2
+module load scorep/3.1
+
+# correct papi module
+module unload papi
+module use /short/z35/dsr900/tools/Modules
+module load papi/5.1.1-patched

--- a/bld/config.scorep.auscom.360x300
+++ b/bld/config.scorep.auscom.360x300
@@ -1,0 +1,21 @@
+
+setenv NTASK 24
+setenv RES 360x300
+set NXGLOB = `echo $RES | sed s/x.\*//`
+set NYGLOB = `echo $RES | sed s/.\*x//`
+
+setenv BLCKX `expr $NXGLOB / 24`       # x-dimension of blocks ( not including )
+setenv BLCKY `expr $NYGLOB / 1`        # y-dimension of blocks (  ghost cells  )
+
+source /etc/profile.d/nf_csh_modules
+module purge
+module load intel-fc/17.0.1.132
+module load intel-cc/17.0.1.132
+module load netcdf/4.2.1.1
+module load openmpi/1.10.2
+module load scorep/3.1
+
+# correct papi module
+module unload papi
+module use /short/z35/dsr900/tools/Modules
+module load papi/5.1.1-patched

--- a/drivers/auscom/CICE_InitMod.F90
+++ b/drivers/auscom/CICE_InitMod.F90
@@ -20,7 +20,8 @@
       use cpl_parameters
       use cpl_parameters, only : read_namelist_parameters, accessom2_config_dir
       use cpl_forcing_handler, only : get_time0_sstsss, get_u_star
-      use cpl_interface , only : prism_init, init_cpl, il_commlocal, il_commatm
+      use cpl_interface , only : prism_init, init_cpl, il_commlocal
+      use cpl_interface, only: coupler
       use cpl_arrays_setup, only : gwork, u_star0
       use ice_gather_scatter
 
@@ -126,7 +127,7 @@
                                           num_ocean_to_ice_fields=n_o2i)
 
       ! Synchronise accessom2 configuration between all models and PEs
-      call accessom2%sync_config(il_commatm, -1, -1)
+      call accessom2%sync_config(coupler)
 
       ! Use accessom2 configuration
       call input_data(accessom2%get_cur_exp_date_array(), &


### PR DESCRIPTION
This patch modifies CICE to support changes to libaccessom2 which allow
the user to disable intercommunicators, instead using MPI_COMM_WORLD to
exchange messages between models.  This work is primarily to support
limitations in the Score-P profiler.

Specific changed detailed below.

- accessom2%config_sync uses the new API, and requires an libaccessom2
  update.

- il_commatm has been removed from cpl_interface, since coupler%atm_root
  provides this information.

- Most of the work in prism_init has been removed are replaced with
  equivalent operations in coupler%init_begin.

- Explicit MPI send/recv calls now use ranks provided by coupler, rather
  than explicit sends to 0 over OASIS-provided intercommunicators.

- Similarly, data sends now happen on the zero rank of CICE, rather than
  checking if the atmosphere rank of the intercommunicator is zero.
  Functionally, there should be no difference, but beware the
  unexpected.

- Buildscripts for score-p have been added.

Further changes to cpl_interface are possible, since most of the MPI
information is provided by the coupler object.