### PR TITLE
Changed netcdf creation mode to NF90_CLASSIC_MODEL

### DIFF
--- a/io_netcdf/ice_history_write.F90
+++ b/io_netcdf/ice_history_write.F90
@@ -127,7 +127,7 @@
         endif
 
         ! create file
-        status = nf90_create(ncfile(ns), NF90_CLASSIC_MODEL, ncid)
+        status = nf90_create(ncfile(ns), IOR(NF90_HDF5, NF90_CLASSIC_MODEL), ncid)
         if (status /= nf90_noerr) call abort_ice( &
            'ice: Error creating history ncfile '//ncfile(ns))
 

--- a/io_netcdf/ice_history_write.F90
+++ b/io_netcdf/ice_history_write.F90
@@ -127,7 +127,7 @@
         endif
 
         ! create file
-        status = nf90_create(ncfile(ns), NF90_HDF5, ncid)
+        status = nf90_create(ncfile(ns), NF90_CLASSIC_MODEL, ncid)
         if (status /= nf90_noerr) call abort_ice( &
            'ice: Error creating history ncfile '//ncfile(ns))
 

--- a/io_netcdf/ice_restart.F90
+++ b/io_netcdf/ice_restart.F90
@@ -194,7 +194,7 @@
          write(nu_rst_pointer,'(a)') filename
          close(nu_rst_pointer)
 
-         status = nf90_create(trim(filename), NF90_CLASSIC_MODEL, ncid)
+         status = nf90_create(trim(filename), IOR(NF90_HDF5, NF90_CLASSIC_MODEL), ncid)
          if (status /= nf90_noerr) call abort_ice( &
             'ice: Error creating restart ncfile '//trim(filename))
 

--- a/io_netcdf/ice_restart.F90
+++ b/io_netcdf/ice_restart.F90
@@ -194,7 +194,7 @@
          write(nu_rst_pointer,'(a)') filename
          close(nu_rst_pointer)
 
-         status = nf90_create(trim(filename), NF90_HDF5, ncid)
+         status = nf90_create(trim(filename), NF90_CLASSIC_MODEL, ncid)
          if (status /= nf90_noerr) call abort_ice( &
             'ice: Error creating restart ncfile '//trim(filename))
 


### PR DESCRIPTION
Changed netcdf creation mode to NF90_CLASSIC_MODEL. This is backwards compatible, and so is better supported by a wider range of software.

There are no new features currently being used that necessitate using
NF90_HDF5, so there should be only upsides and no downsides to this change.